### PR TITLE
Added support for Conan as a dependency manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,123 @@
+### C++ template
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+### CMake template
+CMakeLists.txt.user
+CMakeCache.txt
+CMakeFiles
+CMakeScripts
+Testing
+Makefile
+cmake_install.cmake
+install_manifest.txt
+compile_commands.json
+CTestTestfile.cmake
+_deps
+
+### JetBrains template
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+.idea/
+tmp/*
+test_package/build/*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,10 @@ cmake_minimum_required(VERSION 3.1)
 
 project(Libnest2D)
 
-set(CMAKE_CXX_STANDARD 11)
-set(CMAKE_CXX_STANDARD_REQUIRED)
+# Use C++17 Standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_EXTENSIONS OFF)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 # Add our own cmake module path.
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake_modules/)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,7 +162,7 @@ install(
   FILES
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
-    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindClipper.cmake"
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/Findclipper.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindNLopt.cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake_modules/FindTBB.cmake"
   DESTINATION

--- a/cmake_modules/Findclipper.cmake
+++ b/cmake_modules/Findclipper.cmake
@@ -74,11 +74,11 @@ MARK_AS_ADVANCED(
     CLIPPER_LIBRARIES)
 
 if(CLIPPER_FOUND)
-    add_library(Clipper::Clipper UNKNOWN IMPORTED)
-    set_target_properties(Clipper::Clipper PROPERTIES IMPORTED_LOCATION ${CLIPPER_LIBRARIES})
-    set_target_properties(Clipper::Clipper PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CLIPPER_INCLUDE_DIRS})
+    add_library(clipper::clipper UNKNOWN IMPORTED)
+    set_target_properties(clipper::clipper PROPERTIES IMPORTED_LOCATION ${CLIPPER_LIBRARIES})
+    set_target_properties(clipper::clipper PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CLIPPER_INCLUDE_DIRS})
     if(CLIPPER_LIBRARIES_RELEASE AND CLIPPER_LIBRARIES_DEBUG)
-        set_target_properties(Clipper::Clipper PROPERTIES
+        set_target_properties(clipper::clipper PROPERTIES
             IMPORTED_LOCATION_DEBUG          ${CLIPPER_LIBRARIES_DEBUG}
             IMPORTED_LOCATION_RELWITHDEBINFO ${CLIPPER_LIBRARIES_RELEASE}
             IMPORTED_LOCATION_RELEASE        ${CLIPPER_LIBRARIES_RELEASE}

--- a/conanfile.py
+++ b/conanfile.py
@@ -1,0 +1,150 @@
+from conans import ConanFile, tools
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
+
+class libnest2dConan(ConanFile):
+    name = "libnest2d"
+    version = "4.10.0"
+    license = "LGPL-3.0"
+    author = "Ultimaker B.V."
+    url = "https://github.com/Ultimaker/libnest2d"
+    description = "2D irregular bin packaging and nesting library written in modern C++"
+    topics = ("conan", "cura", "prusaslicer", "nesting", "c++", "bin packaging")
+    settings = "os", "compiler", "build_type", "arch"
+    exports = "LICENSE.txt"
+    options = {
+        "shared": [True, False],
+        "fPIC": [True, False],
+        "tests": [True, False],
+        "header_only": [True, False],
+        "geometries": ["clipper", "boost", "eigen"],
+        "optimizer": ["nlopt", "optimlib"],
+        "threading": ["std", "tbb", "omp", "none"],
+        "python_version": "ANY"
+    }
+    default_options = {
+        "shared": True,
+        "tests": False,
+        "fPIC": True,
+        "header_only": False,
+        "geometries": "clipper",
+        "optimizer": "nlopt",
+        "threading": "std",
+        "python_version": "3.9"
+    }
+    scm = {
+        "type": "git",
+        "subfolder": ".",
+        "url": "auto",
+        "revision": "auto"
+    }
+
+    # TODO: Move lib naming logic to python_requires project
+    _ext = None
+
+    @property
+    def ext(self):
+        if self._ext:
+            return self._ext
+        self._ext = "lib" if self.settings.os == "Windows" else "a"
+        if self.options.shared:
+            if self.settings.os == "Windows":
+                self._ext = "dll"
+            elif self.settings.os == "Macos":
+                self._ext = "dylib"
+            else:
+                self._ext = "so"
+        return self._ext
+
+    _lib_name = None
+
+    @property
+    def lib_name(self):
+        if self._lib_name:
+            return self._lib_name
+        ext = "d" if self.settings.build_type == "Debug" else ""
+        ext += "" if self.settings.os == "Windows" else f".{self.ext}"
+        self._lib_name = f"{self.name}_{self.options.geometries}_{self.options.optimizer}{ext}"
+        return self._lib_name
+
+    def configure(self):
+        if self.options.shared or self.settings.compiler == "Visual Studio":
+            del self.options.fPIC
+        if self.options.geometries == "clipper":
+            self.options["clipper"].shared = self.options.shared
+            self.options["boost"].header_only = True
+            self.options["boost"].python_version = self.options.python_version
+            self.options["boost"].shared = self.options.shared
+        if self.options.optimizer == "nlopt":
+            self.options["nlopt"].shared = self.options.shared
+
+    def build_requirements(self):
+        self.build_requires("cmake/[>=3.16.2]")
+        if self.options.tests:
+            self.build_requires("catch2/[>=2.13.6]", force_host_context=True)
+
+    def requirements(self):
+        if self.options.geometries == "clipper":
+            self.requires("clipper/[>=6.4.2]")
+            self.requires("boost/1.70.0")
+        elif self.options.geometries == "eigen":
+            self.requires("eigen/[>=3.3.7]")
+        if self.options.optimizer == "nlopt":
+            self.requires("nlopt/[>=2.7.0]")
+
+    def validate(self):
+        if self.settings.compiler.get_safe("cppstd"):
+            tools.check_min_cppstd(self, 17)
+
+    def generate(self):
+        cmake = CMakeDeps(self)
+        cmake.generate()
+
+        tc = CMakeToolchain(self)
+
+        # FIXME: This shouldn't be necessary (maybe a bug in Conan????)
+        if self.settings.compiler == "Visual Studio":
+            tc.blocks["generic_system"].values["generator_platform"] = None
+            tc.blocks["generic_system"].values["toolset"] = None
+
+        tc.variables["LIBNEST2D_HEADER_ONLY"] = self.options.header_only
+        if self.options.header_only:
+            tc.variables["BUILD_SHARED_LIBS"] = False
+        else:
+            tc.variables["BUILD_SHARED_LIBS"] = self.options.shared
+        tc.variables["LIBNEST2D_BUILD_UNITTESTS"] = self.options.tests
+        tc.variables["LIBNEST2D_GEOMETRIES"] = self.options.geometries
+        tc.variables["LIBNEST2D_OPTIMIZER"] = self.options.optimizer
+        tc.variables["LIBNEST2D_THREADING"] = self.options.threading
+        tc.generate()
+
+    _cmake = None
+
+    def configure_cmake(self):
+        if self._cmake:
+            return self._cmake
+        self._cmake = CMake(self)
+        self._cmake.configure()
+        return self._cmake
+
+    def build(self):
+        cmake = self.configure_cmake()
+        cmake.build()
+
+    def package(self):
+        cmake = self.configure_cmake()
+        cmake.install()
+
+    def package_info(self):
+        self.cpp_info.includedirs = ["include"]
+        if self.in_local_cache:
+            self.cpp_info.libdirs = ["lib"]
+        else:
+            self.cpp_info.libdirs = [f"cmake-build-{self.settings.build_type}".lower()]
+        self.cpp_info.libs = [self.lib_name]
+        self.cpp_info.defines.append(f"LIBNEST2D_GEOMETRIES_{self.options.geometries}")
+        self.cpp_info.defines.append(f"LIBNEST2D_OPTIMIZERS_{self.options.optimizer}")
+        self.cpp_info.defines.append(f"LIBNEST2D_THREADING_{self.options.threading}")
+        self.cpp_info.names["cmake_find_package"] = self.name
+        self.cpp_info.names["cmake_find_package_multi"] = self.name
+        if self.settings.os in ["Linux", "FreeBSD", "Macos"]:
+            self.cpp_info.system_libs.append("pthread")

--- a/external/+Clipper/CMakeLists.txt
+++ b/external/+Clipper/CMakeLists.txt
@@ -1,5 +1,5 @@
-require_dependency(Boost)
+require_dependency(boost)
 
-rp_add_cmake_project(Clipper
+rp_add_cmake_project(clipper
     GIT_REPOSITORY      https://github.com/tamasmeszaros/libpolyclipping.git
 )

--- a/include/libnest2d/backends/clipper/CMakeLists.txt
+++ b/include/libnest2d/backends/clipper/CMakeLists.txt
@@ -1,7 +1,14 @@
 add_library(clipperBackend INTERFACE)
 
-require_package(Clipper 6.1 REQUIRED)
-target_link_libraries(clipperBackend INTERFACE Clipper::Clipper)
+find_package(polyclipping 6.1 QUIET)
+if(NOT TARGET polyclipping::polyclipping)
+    message(STATUS "Using require_package to obtain Clipper")
+    require_package(Clipper 6.1 REQUIRED)
+    add_library(polyclipping::polyclipping INTERFACE IMPORTED)
+    target_link_libraries(polyclipping::polyclipping INTERFACE Clipper::Clipper)
+endif()
+target_link_libraries(clipperBackend INTERFACE polyclipping::polyclipping)
+
 
 # Clipper backend is not enough on its own, it still need some functions
 # from Boost geometry

--- a/include/libnest2d/backends/clipper/CMakeLists.txt
+++ b/include/libnest2d/backends/clipper/CMakeLists.txt
@@ -1,21 +1,20 @@
 add_library(clipperBackend INTERFACE)
 
-find_package(polyclipping 6.1 QUIET)
-if(NOT TARGET polyclipping::polyclipping)
+find_package(clipper 6.1 QUIET)
+if(NOT TARGET clipper::clipper)
     message(STATUS "Using require_package to obtain Clipper")
     require_package(Clipper 6.1 REQUIRED)
-    add_library(polyclipping::polyclipping INTERFACE IMPORTED)
-    target_link_libraries(polyclipping::polyclipping INTERFACE Clipper::Clipper)
+    add_library(clipper::clipper INTERFACE IMPORTED)
 endif()
-target_link_libraries(clipperBackend INTERFACE polyclipping::polyclipping)
+target_link_libraries(clipperBackend INTERFACE clipper::clipper)
 
 
 # Clipper backend is not enough on its own, it still need some functions
 # from Boost geometry
-require_package(Boost 1.58 REQUIRED)
+require_package(boost 1.58 REQUIRED)
 
-if(TARGET Boost::boost)
-    target_link_libraries(clipperBackend INTERFACE Boost::boost )
+if(TARGET boost::boost)
+    target_link_libraries(clipperBackend INTERFACE boost::boost )
 elseif(Boost_INCLUDE_DIRS_FOUND)
     target_include_directories(clipperBackend INTERFACE $<BUILD_INTERFACE:${Boost_INCLUDE_DIRS}> )
 endif()

--- a/include/libnest2d/backends/clipper/clipper_polygon.hpp
+++ b/include/libnest2d/backends/clipper/clipper_polygon.hpp
@@ -1,7 +1,7 @@
 #ifndef CLIPPER_POLYGON_HPP
 #define CLIPPER_POLYGON_HPP
 
-#include <clipper.hpp>
+#include <polyclipping/clipper.hpp>
 
 namespace ClipperLib {
 

--- a/test_package/CMakeLists.txt
+++ b/test_package/CMakeLists.txt
@@ -1,0 +1,10 @@
+cmake_minimum_required(VERSION 3.13)
+
+project(Libnest2D_example)
+set(CMAKE_CXX_STANDARD 17)
+find_package(libnest2d REQUIRED)
+
+add_executable(test main.cpp)
+
+target_link_libraries(test PRIVATE libnest2d::libnest2d)
+target_include_directories(test PRIVATE ${libnest2d_INCLUDE_DIRS})

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,5 +1,4 @@
-import os
-from conans import ConanFile, CMake, tools
+from conans import ConanFile, CMake
 from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
 
 
@@ -10,7 +9,7 @@ class LibNest2DTestConan(ConanFile):
         self.build_requires("cmake/[>=3.16.2]")
 
     def requirements(self):
-        self.requires(f"libnest2d/4.10.0@ultimaker/testing")
+        self.requires(f"libnest2d/4.11.0@ultimaker/testing")
 
     def generate(self):
         cmake = CMakeDeps(self)

--- a/test_package/conanfile.py
+++ b/test_package/conanfile.py
@@ -1,0 +1,35 @@
+import os
+from conans import ConanFile, CMake, tools
+from conan.tools.cmake import CMakeToolchain, CMakeDeps, CMake
+
+
+class LibNest2DTestConan(ConanFile):
+    settings = "os", "compiler", "build_type", "arch"
+
+    def build_requirements(self):
+        self.build_requires("cmake/[>=3.16.2]")
+
+    def requirements(self):
+        self.requires(f"libnest2d/4.10.0@ultimaker/testing")
+
+    def generate(self):
+        cmake = CMakeDeps(self)
+        cmake.generate()
+        tc = CMakeToolchain(self)
+        if self.settings.compiler == "Visual Studio":
+            tc.blocks["generic_system"].values["generator_platform"] = None
+            tc.blocks["generic_system"].values["toolset"] = None
+        tc.generate()
+
+    def build(self):
+        cmake = CMake(self)
+        cmake.configure()
+        cmake.build()
+
+    def imports(self):
+        self.copy("*.dll", str(self.settings.build_type), "lib")
+        self.copy("*.dll", str(self.settings.build_type), "lib")
+        self.copy("*.dylib", str(self.settings.build_type), "lib")
+
+    def test(self):
+        pass # only interested in compiling and linking

--- a/test_package/main.cpp
+++ b/test_package/main.cpp
@@ -1,0 +1,6 @@
+#include <libnest2d/nester.hpp>
+
+int main(void /*int argc, char **argv*/) {
+    auto pi = libnest2d::Pi;
+    return 0;
+}


### PR DESCRIPTION
This PR is part of the following PRs:
- libArcus-> Ultimaker/libArcus#122
- libSavitar -> Ultimaker/libSavitar#36
- libCharon -> Ultimaker/libCharon#33
- pynest2d -> Ultimaker/pynest2d#11
- Uranium -> Ultimaker/Uranium#720
- CuraEngine -> Ultimaker/CuraEngine#1479
- Cura -> Ultimaker/Cura#10535

The purpose of these changes is to set up a dependency manager for Cura and here repositories. Cura uses both third-party and Ultimaker maintained dependencies, written in both Python and C++ (or mixtures of both). Not all of these dependencies can be downloaded with the help of a dependency manager such as pip. This makes setting up Cura from source, a pain in the $%^#$$%^. See the graph below for the current dependencies. Adding to the complexity is the way how we're currently consuming third-party dependencies; Some have to be present on the system/provided by the user, some are shipped within the repo, while others are downloaded by CMake.

![dep graph](https://raw.githubusercontent.com/jellespijker/conan-um/main/resources/Cura_deps.png)

All of the above-mentioned PRs and this one, add a `conanfile.py` to the root of this project. This is a recipe written in Python which instructs Conan (https://docs.conan.io/en/latest/) how to build and package the repository in such a way that it can be reused by other dependencies. If a required dependency has no binary for your OS and compiler it will build that dependency from scratch and store it in the cache.  Making installing Cura from source as simple as:
```bash
conan install Cura/4.10.0@ultimaker/testing --build=missing
```
For a more detailed description see the README.md in this repository https://github.com/jellespijker/conan-um

For testing purposes, I have set up a small home server that can be used by Ultimaker employees. Other developers can test this by cloning the above-mentioned repositories and performing a `conan export . ultimaker/testing` in each root. That only leaves the SIP package, if you execute a `conan export . riverbankingcomputing/testing` in this folder https://github.com/jellespijker/conan-um/tree/main/recipes/sip it creates a Conan package for SIP 4.19.25 

You can use your own profiles for this, but I have personally tested and developed them with my own `jinja` template profiles on Linux Manjaro with a GCC compiler, Mac OS Big Sur with a Clang compiler and Windows 11 with a Visual Studio 2019 compiler.
These profiles can be installed with the `conan config install https://github.com/jellespijker/conan-config`. Make sure you add ` -pr:b cura_release.jinja -pr:h cura_release.jinja` to your install instructions

Conan allows for multiple ways of working. Either the exiting package can be used from the cache, or if you want to work on multiple repositories you can put that repo in editable mode such that the **xxx-config.cmake** in the project that is depending on the other, will point to the paths of your repo, see https://docs.conan.io/en/latest/developing_packages/editable_packages.html 

Because the best practice method to use Conan, which is also the preferred way in Conan 2.0, is to use ( https://docs.conan.io/en/latest/reference/conanfile/tools/cmake.html ) With the tools `CMakeDeps`, `CMakeToolchain`, and `CMake`. The `CMakeDeps` class will generate **xxx-config.cmake** files per dependency, while the `CMakeToolchain` will generate a toolchain to be passed to CMake `-DCMAKE_TOOLCHAIN_FILE=conan_toolchain.cmake` These two prepare the way for `CMake` to actually build the project such that it won't need to change the **CMakeLists.txt**.  Allowing Conan to be optional and not mandatory.  Because this project imports polyclipping as Clipper I had to make some small adjustmenst to the CMakeLists.txt this shouldn't affect the build interface

Still, WIP at the moment, since I'm finalizing some last changes across all repos.
