### PR TITLE
Update nlopt dependency to version 2.10.0

### DIFF
--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "5.10.0"
+version: "5.12.0-alpha.0"

--- a/conandata.yml
+++ b/conandata.yml
@@ -1,1 +1,1 @@
-version: "5.12.0-alpha.0"
+version: "5.11.0-alpha.0"

--- a/conanfile.py
+++ b/conanfile.py
@@ -95,7 +95,7 @@ class Nest2DConan(ConanFile):
         if self.options.geometries == "boost" or self.options.geometries == "clipper":
             self.requires("boost/1.88.0", transitive_headers=True)
         if self.options.optimizer == "nlopt":
-            self.requires("nlopt/2.7.1", transitive_headers=True)
+            self.requires("nlopt/2.10.0", transitive_headers=True)
         if self.options.optimizer == "optimlib":
             self.requires("armadillo/12.6.4", transitive_headers=True)
         if self.options.threading == "tbb":


### PR DESCRIPTION
This pull request updates a dependency version in the `conanfile.py` requirements. The change ensures that the project uses a newer version of the `nlopt` optimizer library.

Dependency updates:

* Updated the required version of `nlopt` from `2.7.1` to `2.10.0` in the `requirements` method of `conanfile.py`, ensuring compatibility with the latest features and bug fixes.

CURA-12814